### PR TITLE
Feature : 멤버 관련 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,16 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
+
+    /* 로그인 관련 */
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    /* jwt 관련 */
+    implementation "com.auth0:java-jwt:$javaJwtVersion"
+
+    /* model validation 관련 */
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 mysqlVersion=8.0.27
+javaJwtVersion=3.18.3

--- a/src/main/java/com/comeet/CoMeetApplication.java
+++ b/src/main/java/com/comeet/CoMeetApplication.java
@@ -2,8 +2,10 @@ package com.comeet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CoMeetApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/comeet/HelloController.java
+++ b/src/main/java/com/comeet/HelloController.java
@@ -1,0 +1,15 @@
+package com.comeet;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1")
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello, comeet-api-server";
+    }
+}

--- a/src/main/java/com/comeet/commit/Commit.java
+++ b/src/main/java/com/comeet/commit/Commit.java
@@ -1,7 +1,7 @@
 package com.comeet.commit;
 
 import com.comeet.common.entities.BaseEntity;
-import com.comeet.member.Member;
+import com.comeet.member.entity.Member;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;

--- a/src/main/java/com/comeet/common/ApiControllerAdvice.java
+++ b/src/main/java/com/comeet/common/ApiControllerAdvice.java
@@ -6,9 +6,12 @@ import com.comeet.common.exceptions.InternalServerErrorException;
 import com.comeet.common.exceptions.NotFoundException;
 import com.comeet.common.exceptions.ServiceUnavailableException;
 import com.comeet.common.exceptions.UnauthorizedException;
+import java.security.Principal;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.HttpMediaTypeException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -18,6 +21,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class ApiControllerAdvice {
+
+    @ModelAttribute("memberId")
+    public Long resolveMemberId(Principal principal) {
+        if (principal == null) {
+            return null;
+        }
+        if (principal instanceof PreAuthenticatedAuthenticationToken) {
+            return (Long) ((PreAuthenticatedAuthenticationToken) principal).getPrincipal();
+        }
+        return null;
+    }
 
     @ExceptionHandler(HttpMediaTypeException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/comeet/common/ResultCode.java
+++ b/src/main/java/com/comeet/common/ResultCode.java
@@ -14,8 +14,8 @@ public enum ResultCode {
     MEMBER_NOT_FOUND("사용자가 존재하지 않습니다."),
     MEMBER_NICKNAME_ALREADY_EXIST("이미 존재하는 닉네임입니다."),
 
-    // partner (파트너)
-    PARTNER_NOT_FOUND("파트너가 존재하지 않습니다.");
+    // github (깃헙)
+    Github_USER_NOT_FOUND("사용자가 존재하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/com/comeet/config/jwt/JwtService.java
+++ b/src/main/java/com/comeet/config/jwt/JwtService.java
@@ -1,0 +1,44 @@
+package com.comeet.config.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class JwtService {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    private static final String CLAIM_NAME_MEMBER_ID = "MemberId";
+    private Algorithm algorithm;
+    private JWTVerifier jwtVerifier;
+
+    public String encode(Long memberId) {
+        return JWT.create()
+            .withClaim(CLAIM_NAME_MEMBER_ID, memberId)
+            .sign(algorithm);
+    }
+
+    public Long decode(String token) {
+        try {
+            return jwtVerifier.verify(token).getClaim(CLAIM_NAME_MEMBER_ID).asLong();
+        } catch (JWTVerificationException e) {
+            log.warn("Failed to decode jwt. token: {}", token, e);
+            return null;
+        }
+    }
+
+    @PostConstruct
+    private void init() {
+        algorithm = Algorithm.HMAC256(secretKey);
+        jwtVerifier = JWT.require(algorithm).build();
+    }
+}
+

--- a/src/main/java/com/comeet/config/security/PreAuthTokenProvider.java
+++ b/src/main/java/com/comeet/config/security/PreAuthTokenProvider.java
@@ -1,0 +1,45 @@
+package com.comeet.config.security;
+
+import com.comeet.config.jwt.JwtService;
+import com.comeet.config.security.exception.TokenMissingException;
+import com.comeet.member.entity.Member;
+import com.comeet.member.repository.MemberRepository;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+@RequiredArgsConstructor
+public class PreAuthTokenProvider implements AuthenticationProvider {
+
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+        throws AuthenticationException {
+        if (authentication instanceof PreAuthenticatedAuthenticationToken) {
+            String token = authentication.getPrincipal().toString();
+            Long memberId = jwtService.decode(token);
+            // TODO: 멤버 조회 실패하는 경우, AuthenticationException 으로 예외번역
+            Member member = memberRepository.getById(memberId);
+            return new PreAuthenticatedAuthenticationToken(
+                member.getId(),
+                "",
+                Collections.singletonList(
+                    new SimpleGrantedAuthority(SecurityConfig.MEMBER_ROLE_NAME))
+            );
+        }
+        throw new TokenMissingException("Invalid token");
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return PreAuthenticatedAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+}

--- a/src/main/java/com/comeet/config/security/SecurityConfig.java
+++ b/src/main/java/com/comeet/config/security/SecurityConfig.java
@@ -1,0 +1,116 @@
+package com.comeet.config.security;
+
+import com.comeet.common.ApiResponse;
+import com.comeet.common.ResultCode;
+import com.comeet.config.jwt.JwtService;
+import com.comeet.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@RequiredArgsConstructor
+@EnableWebSecurity(debug = true)
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    public static final String MEMBER_ROLE_NAME = "MEMBER";
+
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web
+            .ignoring()
+            .mvcMatchers(
+                "/error",
+                "/favicon.ico",
+                "/swagger-ui/**",
+                "/webjars/springfox-swagger-ui/**",
+                "/swagger-resources/**",
+                "/v1/api-docs",
+                "/h2-console/**",
+                "/api/v1/hello",
+                "/api/v1/check-github/**",
+                "/api/v1/check-nickname/**"
+            );
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.antMatcher("/api/v1/**")
+            .authorizeRequests()
+            .antMatchers("/api/v1/members/join").permitAll()
+            .antMatchers("/api/v1/members/login").permitAll()
+            .anyRequest().hasAuthority(MEMBER_ROLE_NAME);
+        http.cors().configurationSource(corsConfigurationSource());
+        http.csrf().disable();
+        http.logout().disable();
+        http.formLogin().disable();
+        http.httpBasic().disable();
+        http.requestCache().disable();
+        http.addFilterAt(tokenPreAuthFilter(), AbstractPreAuthenticatedProcessingFilter.class);
+        http.sessionManagement().disable();
+        http.exceptionHandling()
+            .authenticationEntryPoint((request, response, authException) -> {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                objectMapper.writeValue(
+                    response.getOutputStream(),
+                    ApiResponse.failure(ResultCode.UNAUTHORIZED)
+                );
+            })
+            .accessDeniedHandler((request, response, accessDeniedException) -> {
+                response.setStatus(HttpStatus.FORBIDDEN.value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                objectMapper.writeValue(
+                    response.getOutputStream(),
+                    ApiResponse.failure(ResultCode.FORBIDDEN)
+                );
+            });
+    }
+
+    @Bean
+    TokenPreAuthFilter tokenPreAuthFilter() {
+        TokenPreAuthFilter tokenPreAuthFilter = new TokenPreAuthFilter();
+        tokenPreAuthFilter.setAuthenticationManager(new ProviderManager(preAuthTokenProvider()));
+        return tokenPreAuthFilter;
+    }
+
+    @Bean
+    PreAuthTokenProvider preAuthTokenProvider() {
+        return new PreAuthTokenProvider(
+            memberRepository,
+            jwtService
+        );
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+}

--- a/src/main/java/com/comeet/config/security/TokenPreAuthFilter.java
+++ b/src/main/java/com/comeet/config/security/TokenPreAuthFilter.java
@@ -1,0 +1,39 @@
+package com.comeet.config.security;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.util.StringUtils;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TokenPreAuthFilter extends AbstractPreAuthenticatedProcessingFilter {
+
+    private static final Pattern BEARER_TOKEN_PATTERN = Pattern.compile("[Bb]earer (.*)");
+    private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+
+    @Override
+    protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
+        return resolveToken(request);
+    }
+
+    @Override
+    protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+        return resolveToken(request);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER_NAME);
+        if (!StringUtils.hasText(authorizationHeader)) {
+            return null;
+        }
+        Matcher matcher = BEARER_TOKEN_PATTERN.matcher(authorizationHeader);
+        if (!matcher.matches()) {
+            return null;
+        } else {
+            return matcher.group(1);
+        }
+    }
+}

--- a/src/main/java/com/comeet/config/security/exception/TokenMissingException.java
+++ b/src/main/java/com/comeet/config/security/exception/TokenMissingException.java
@@ -1,0 +1,14 @@
+package com.comeet.config.security.exception;
+
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public class TokenMissingException extends UsernameNotFoundException {
+
+    public TokenMissingException(String message) {
+        super(message);
+    }
+
+    public TokenMissingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/comeet/member/controller/MemberController.java
+++ b/src/main/java/com/comeet/member/controller/MemberController.java
@@ -1,0 +1,58 @@
+package com.comeet.member.controller;
+
+import com.comeet.common.ApiResponse;
+import com.comeet.member.model.request.JoinRequestDto;
+import com.comeet.member.model.request.LoginRequestDto;
+import com.comeet.member.model.response.GetOrganizationOfMemberDto;
+import com.comeet.member.model.response.JoinResponseDto;
+import com.comeet.member.model.response.LoginResponseDto;
+import com.comeet.member.model.response.MemberInfoResponseDto;
+import com.comeet.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/check-nickname/{nickname}")
+    public ApiResponse<String> checkNickname(@PathVariable String nickname) {
+        return ApiResponse.success(memberService.checkNickname(nickname));
+    }
+
+    @GetMapping("/check-github/{githubId}")
+    public ApiResponse<String> checkGithubId(@PathVariable String githubId) {
+        return ApiResponse.success(memberService.checkGithubId(githubId));
+    }
+
+    @PostMapping("/join")
+    public ApiResponse<JoinResponseDto> join(@RequestBody JoinRequestDto joinRequestDto) {
+        return ApiResponse.success(memberService.join(joinRequestDto));
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+        return ApiResponse.success(memberService.login(loginRequestDto));
+    }
+
+    @PostMapping("/organizations")
+    public ApiResponse<GetOrganizationOfMemberDto> getOrganizationOfMember(
+        @ModelAttribute("memberId") Long memberId) {
+        return ApiResponse.success(memberService.getOrganizationOfMember(memberId));
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<MemberInfoResponseDto> getMyInfo(
+        @ModelAttribute("memberId") Long memberId) {
+        return ApiResponse.success(memberService.getMemberInfo(memberId));
+    }
+}

--- a/src/main/java/com/comeet/member/entity/Member.java
+++ b/src/main/java/com/comeet/member/entity/Member.java
@@ -1,4 +1,4 @@
-package com.comeet.member;
+package com.comeet.member.entity;
 
 import com.comeet.common.entities.BaseEntity;
 import com.comeet.organization.Organization;
@@ -23,4 +23,12 @@ public class Member extends BaseEntity {
     @ManyToMany()
     @JoinTable(name = "member_organization")
     private List<Organization> organizations = new ArrayList<>();
+
+    public static Member of(String nickname, String githubId) {
+
+        Member member = new Member();
+        member.nickname = nickname;
+        member.githubId = githubId;
+        return member;
+    }
 }

--- a/src/main/java/com/comeet/member/exception/GithubUserNotFoundException.java
+++ b/src/main/java/com/comeet/member/exception/GithubUserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.comeet.member.exception;
+
+import com.comeet.common.ResultCode;
+import com.comeet.common.exceptions.NotFoundException;
+
+public class GithubUserNotFoundException extends NotFoundException {
+
+    public GithubUserNotFoundException() {
+        super(ResultCode.Github_USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/comeet/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/comeet/member/exception/MemberNotFoundException.java
@@ -1,0 +1,12 @@
+package com.comeet.member.exception;
+
+
+import com.comeet.common.ResultCode;
+import com.comeet.common.exceptions.NotFoundException;
+
+public class MemberNotFoundException extends NotFoundException {
+
+    public MemberNotFoundException() {
+        super(ResultCode.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/comeet/member/exception/NicknameAlreadyExistsException.java
+++ b/src/main/java/com/comeet/member/exception/NicknameAlreadyExistsException.java
@@ -1,0 +1,5 @@
+package com.comeet.member.exception;
+
+public class NicknameAlreadyExistsException {
+
+}

--- a/src/main/java/com/comeet/member/model/request/JoinRequestDto.java
+++ b/src/main/java/com/comeet/member/model/request/JoinRequestDto.java
@@ -1,0 +1,16 @@
+package com.comeet.member.model.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JoinRequestDto {
+
+    @NotNull
+    private String nickname;
+
+    @NotNull
+    private String githubId;
+}

--- a/src/main/java/com/comeet/member/model/request/LoginRequestDto.java
+++ b/src/main/java/com/comeet/member/model/request/LoginRequestDto.java
@@ -1,0 +1,15 @@
+package com.comeet.member.model.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequestDto {
+
+    @NotNull
+    private String nickname;
+}

--- a/src/main/java/com/comeet/member/model/response/GetOrganizationOfMemberDto.java
+++ b/src/main/java/com/comeet/member/model/response/GetOrganizationOfMemberDto.java
@@ -1,0 +1,13 @@
+package com.comeet.member.model.response;
+
+import com.comeet.organization.Organization;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GetOrganizationOfMemberDto {
+
+    List<Organization> organizationList;
+}

--- a/src/main/java/com/comeet/member/model/response/JoinResponseDto.java
+++ b/src/main/java/com/comeet/member/model/response/JoinResponseDto.java
@@ -1,0 +1,12 @@
+package com.comeet.member.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JoinResponseDto {
+
+    private String accessToken;
+}
+         

--- a/src/main/java/com/comeet/member/model/response/LoginResponseDto.java
+++ b/src/main/java/com/comeet/member/model/response/LoginResponseDto.java
@@ -1,0 +1,12 @@
+package com.comeet.member.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponseDto {
+
+    private String accessToken;
+}
+         

--- a/src/main/java/com/comeet/member/model/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/comeet/member/model/response/MemberInfoResponseDto.java
@@ -1,0 +1,15 @@
+package com.comeet.member.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MemberInfoResponseDto {
+
+    private Long id;
+
+    private String nickname;
+
+    private String githubId;
+}

--- a/src/main/java/com/comeet/member/repository/MemberRepository.java
+++ b/src/main/java/com/comeet/member/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package com.comeet.member.repository;
+
+import com.comeet.member.entity.Member;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+
+    Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByGithubId(String githubId);
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/comeet/member/service/MemberService.java
+++ b/src/main/java/com/comeet/member/service/MemberService.java
@@ -1,0 +1,100 @@
+package com.comeet.member.service;
+
+import com.comeet.config.jwt.JwtService;
+import com.comeet.member.entity.Member;
+import com.comeet.member.exception.GithubUserNotFoundException;
+import com.comeet.member.exception.MemberNotFoundException;
+import com.comeet.member.model.request.JoinRequestDto;
+import com.comeet.member.model.request.LoginRequestDto;
+import com.comeet.member.model.response.GetOrganizationOfMemberDto;
+import com.comeet.member.model.response.JoinResponseDto;
+import com.comeet.member.model.response.LoginResponseDto;
+import com.comeet.member.model.response.MemberInfoResponseDto;
+import com.comeet.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.util.JSONPObject;
+import com.mysql.cj.xdevapi.JsonArray;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.json.JsonParser;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
+
+    public String checkNickname(String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new GithubUserNotFoundException();
+        } else {
+            return "사용가능한 닉네임입니다.";
+        }
+    }
+
+    public String checkGithubId(String githubId) {
+        /**
+         * TODO 외부 API 호출은 추후 리팩토링
+         */
+        String githubUrl = "https://api.github.com/users";
+        RestTemplate restTemplate = new RestTemplate();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("githubId", githubId);
+        try {
+            restTemplate.getForObject(githubUrl + "/{id}", Object.class,
+                githubId);
+            return "해당 깃허브 아이디를 사용하는 유저가 존재합니다.";
+        } catch (HttpStatusCodeException e) {
+            throw new GithubUserNotFoundException();
+        }
+    }
+
+    @Transactional
+    public JoinResponseDto join(JoinRequestDto joinRequestDto) {
+        Member member = Member.of(joinRequestDto.getNickname(), joinRequestDto.getGithubId());
+        memberRepository.save(member);
+
+        return new JoinResponseDto(jwtService.encode(member.getId()));
+    }
+
+    public LoginResponseDto login(LoginRequestDto logInRequestDto) {
+        Member member = memberRepository.findByNickname(logInRequestDto.getNickname())
+            .orElseThrow(MemberNotFoundException::new);
+
+        return new LoginResponseDto(jwtService.encode(member.getId()));
+    }
+
+
+    public MemberInfoResponseDto getMemberInfo(Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+        return new MemberInfoResponseDto(member.getId(), member.getNickname(),
+            member.getGithubId());
+    }
+
+    /**
+     * TODO 멤버 정보 수정
+     */
+
+    public GetOrganizationOfMemberDto getOrganizationOfMember(Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+        return new GetOrganizationOfMemberDto(member.getOrganizations());
+    }
+
+    // 기타 validation 로직은 private 함수로 빼기
+    private Member findByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname).orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/src/main/java/com/comeet/organization/Organization.java
+++ b/src/main/java/com/comeet/organization/Organization.java
@@ -1,7 +1,7 @@
 package com.comeet.organization;
 
 import com.comeet.common.entities.BaseEntity;
-import com.comeet.member.Member;
+import com.comeet.member.entity.Member;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Entity;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,5 @@ spring:
         show_sql: true
         format_sql: true
         default_batch_fetch_size: 100
+jwt:
+  secretKey: secretKey


### PR DESCRIPTION
## 변경사항

### 회원가입 API
- 닉네임과 깃헙 ID로 가입을 진행합니다.
- 닉네임은 유니크해야하며, 깃헙 ID는 중복될 수 있습니다
  → 가입 절차를 간소화 하기 위해, 깃헙 소셜 로그인을 이용하지 않기 때문에 깃헙 ID는 실제 사용자가 존재하는지만 확인합니다.

### 로그인 API
- 멤버 인증 방식은 jwt를 사용합니다. 

### 내 정보 조회 API

### 멤버가 속한 단체 정보 조회 API

### 깃헙 아이디 유효한지 확인하는 API

### 닉네임 중복 체크 API

### JWT 관련 로직 추가

### TODO
- [ ] 닉네임 수정 API
- [x] 닉네임 조회 API