### PR TITLE
Refactor : 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ configurations {
 
 ext {
     snippetsDir = file('build/generated-snippets')
+    set('springCloudVersion', "2021.0.1")
 }
 
 test {
@@ -64,6 +65,9 @@ dependencies {
     /* github commit 관련 */
     implementation "org.kohsuke:github-api:$githubApiVersion"
 
+    /* FeignClient 관련 */
+    implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+
     /* json parse 관련 */
     implementation "com.googlecode.json-simple:json-simple:$jsonSimpleVersion"
 
@@ -74,6 +78,12 @@ dependencies {
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+    }
 }
 
 tasks.named('test') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ javaJwtVersion=3.18.3
 githubApiVersion=1.306
 jsonSimpleVersion=1.1.1
 jasyptVersion=3.0.3
+springCloudVersion=2021.0.1

--- a/src/main/java/com/comeet/CoMeetApplication.java
+++ b/src/main/java/com/comeet/CoMeetApplication.java
@@ -2,8 +2,10 @@ package com.comeet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableFeignClients
 @SpringBootApplication
 @EnableJpaAuditing
 public class CoMeetApplication {

--- a/src/main/java/com/comeet/common/ApiControllerAdvice.java
+++ b/src/main/java/com/comeet/common/ApiControllerAdvice.java
@@ -58,8 +58,6 @@ public class ApiControllerAdvice {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ApiResponse<?> handleNotFoundException(NotFoundException e) {
         log.info("handleNotFoundException: {}", e.getMessage(), e);
-        System.out.println("pass");
-
         return ApiResponse.failure(e.getResultCode());
     }
 

--- a/src/main/java/com/comeet/common/ApiControllerAdvice.java
+++ b/src/main/java/com/comeet/common/ApiControllerAdvice.java
@@ -6,14 +6,10 @@ import com.comeet.common.exceptions.InternalServerErrorException;
 import com.comeet.common.exceptions.NotFoundException;
 import com.comeet.common.exceptions.ServiceUnavailableException;
 import com.comeet.common.exceptions.UnauthorizedException;
-import java.security.Principal;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.HttpMediaTypeException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 

--- a/src/main/java/com/comeet/common/ApiControllerAdvice.java
+++ b/src/main/java/com/comeet/common/ApiControllerAdvice.java
@@ -23,17 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class ApiControllerAdvice {
 
-    @ModelAttribute("memberId")
-    public Long resolveMemberId(Principal principal) {
-        if (principal == null) {
-            return null;
-        }
-        if (principal instanceof PreAuthenticatedAuthenticationToken) {
-            return (Long) ((PreAuthenticatedAuthenticationToken) principal).getPrincipal();
-        }
-        return null;
-    }
-
     @ExceptionHandler(HttpMediaTypeException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<?> handleHttpMediaTypeException(HttpMediaTypeException e) {

--- a/src/main/java/com/comeet/config/feign/GithubFeignClientConfig.java
+++ b/src/main/java/com/comeet/config/feign/GithubFeignClientConfig.java
@@ -1,0 +1,21 @@
+package com.comeet.config.feign;
+
+import com.comeet.github.GithubFeignError;
+import feign.Logger;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GithubFeignClientConfig {
+
+    @Bean
+    Logger.Level githubFeignClientLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new GithubFeignError();
+    }
+}

--- a/src/main/java/com/comeet/config/security/SecurityUtil.java
+++ b/src/main/java/com/comeet/config/security/SecurityUtil.java
@@ -1,0 +1,25 @@
+package com.comeet.config.security;
+
+import java.security.Principal;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+@Slf4j
+public class SecurityUtil {
+
+    private SecurityUtil() {
+    }
+
+    public static Long resolveMemberId() {
+        final Authentication authentication = SecurityContextHolder.getContext()
+            .getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("Security Context 에 인증 정보가 없습니다.");
+        }
+
+        return (Long) authentication.getPrincipal();
+    }
+}

--- a/src/main/java/com/comeet/config/security/SecurityUtil.java
+++ b/src/main/java/com/comeet/config/security/SecurityUtil.java
@@ -1,10 +1,8 @@
 package com.comeet.config.security;
 
-import java.security.Principal;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 @Slf4j
 public class SecurityUtil {

--- a/src/main/java/com/comeet/github/GithubFeignClient.java
+++ b/src/main/java/com/comeet/github/GithubFeignClient.java
@@ -1,0 +1,21 @@
+package com.comeet.github;
+
+import com.comeet.config.feign.GithubFeignClientConfig;
+import com.comeet.github.model.response.GithubCommitsResponseDto;
+import com.comeet.github.model.response.GithubUserResponseDto;
+import java.time.LocalDate;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@FeignClient(name = "githubFeignClient", url = "https://api.github.com", configuration = GithubFeignClientConfig.class)
+public interface GithubFeignClient {
+
+    @RequestMapping(method = RequestMethod.GET, value = "/users/{githubId}")
+    GithubUserResponseDto getGithubUser(@PathVariable("githubId") String githubId);
+
+    @RequestMapping(method = RequestMethod.GET, value = "/search/commits?q=author:{author} committer-date:{committerDate}")
+    GithubCommitsResponseDto getGithubCommits(@PathVariable("author") String author,
+        @PathVariable("committerDate") LocalDate committerDate);
+}

--- a/src/main/java/com/comeet/github/GithubFeignError.java
+++ b/src/main/java/com/comeet/github/GithubFeignError.java
@@ -1,0 +1,17 @@
+package com.comeet.github;
+
+import com.comeet.member.exception.GithubUserNotFoundException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class GithubFeignError implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        switch (response.status()) {
+            case 404:
+                return new GithubUserNotFoundException();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/comeet/github/GithubFeignService.java
+++ b/src/main/java/com/comeet/github/GithubFeignService.java
@@ -1,0 +1,28 @@
+package com.comeet.github;
+
+import com.comeet.github.model.response.GithubCommitsResponseDto;
+import com.comeet.github.model.response.GithubUserResponseDto;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class GithubFeignService {
+
+    private final GithubFeignClient githubFeignClient;
+
+    public GithubUserResponseDto getGithubUser(String githubId) {
+        return githubFeignClient.getGithubUser(githubId);
+    }
+
+    public GithubCommitsResponseDto getGithubCommits(String author) {
+        LocalDate committerDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        return githubFeignClient.getGithubCommits(author, committerDate);
+    }
+}

--- a/src/main/java/com/comeet/github/model/response/GithubCommitsResponseDto.java
+++ b/src/main/java/com/comeet/github/model/response/GithubCommitsResponseDto.java
@@ -1,0 +1,13 @@
+package com.comeet.github.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GithubCommitsResponseDto {
+
+    Long total_count;
+    String incomplete_results;
+    Object items;
+}

--- a/src/main/java/com/comeet/github/model/response/GithubUserResponseDto.java
+++ b/src/main/java/com/comeet/github/model/response/GithubUserResponseDto.java
@@ -1,0 +1,73 @@
+package com.comeet.github.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GithubUserResponseDto {
+
+    String login;
+
+    Long id;
+
+    String node_id;
+
+    String avatar_url;
+
+    String gravatar_id;
+
+    String url;
+
+    String html_url;
+
+    String followers_url;
+
+    String following_url;
+
+    String gists_url;
+
+    String starred_url;
+
+    String subscriptions_url;
+
+    String organizations_url;
+
+    String repos_url;
+
+    String events_url;
+
+    String received_events_url;
+
+    String type;
+
+    String site_admin;
+
+    String name;
+
+    String company;
+
+    String blog;
+
+    String location;
+
+    String email;
+
+    String hireable;
+
+    String bio;
+
+    String twitter_username;
+
+    Long public_repos;
+
+    Long public_gists;
+
+    Long followers;
+
+    Long following;
+
+    String created_at;
+
+    String updated_at;
+}

--- a/src/main/java/com/comeet/member/controller/MemberController.java
+++ b/src/main/java/com/comeet/member/controller/MemberController.java
@@ -45,14 +45,12 @@ public class MemberController {
     }
 
     @GetMapping("/organizations")
-    public ApiResponse<GetOrganizationOfMemberDto> getOrganizationOfMember(
-        @ModelAttribute("memberId") Long memberId) {
-        return ApiResponse.success(memberService.getOrganizationOfMember(memberId));
+    public ApiResponse<GetOrganizationOfMemberDto> getOrganizationOfMember() {
+        return ApiResponse.success(memberService.getOrganizationOfMember());
     }
 
     @GetMapping("/me")
-    public ApiResponse<MemberInfoResponseDto> getMyInfo(
-        @ModelAttribute("memberId") Long memberId) {
-        return ApiResponse.success(memberService.getMemberInfo(memberId));
+    public ApiResponse<MemberInfoResponseDto> getMyInfo() {
+        return ApiResponse.success(memberService.getMemberInfo());
     }
 }

--- a/src/main/java/com/comeet/member/service/MemberService.java
+++ b/src/main/java/com/comeet/member/service/MemberService.java
@@ -2,6 +2,8 @@ package com.comeet.member.service;
 
 import com.comeet.config.jwt.JwtService;
 import com.comeet.config.security.SecurityUtil;
+import com.comeet.github.GithubFeignService;
+import com.comeet.github.model.response.GithubUserResponseDto;
 import com.comeet.member.entity.Member;
 import com.comeet.member.exception.GithubUserNotFoundException;
 import com.comeet.member.exception.MemberNotFoundException;
@@ -30,6 +32,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
+    private final GithubFeignService githubFeignService;
 
     public String checkNickname(String nickname) {
         if (memberRepository.existsByNickname(nickname)) {
@@ -40,21 +43,8 @@ public class MemberService {
     }
 
     public String checkGithubId(String githubId) {
-        /**
-         * TODO 외부 API 호출은 추후 리팩토링
-         */
-        String githubUrl = "https://api.github.com/users";
-        RestTemplate restTemplate = new RestTemplate();
-
-        Map<String, Object> params = new HashMap<>();
-        params.put("id", githubId);
-        try {
-            restTemplate.getForObject(githubUrl + "/{id}", Object.class,
-                params);
-            return "해당 깃허브 아이디를 사용하는 유저가 존재합니다.";
-        } catch (HttpStatusCodeException e) {
-            throw new GithubUserNotFoundException();
-        }
+        githubFeignService.getGithubUser(githubId);
+        return githubId + "를(을) 사용하는 유저가 존재합니다.";
     }
 
     @Transactional

--- a/src/main/java/com/comeet/member/service/MemberService.java
+++ b/src/main/java/com/comeet/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.comeet.member.service;
 
 import com.comeet.config.jwt.JwtService;
+import com.comeet.config.security.SecurityUtil;
 import com.comeet.member.entity.Member;
 import com.comeet.member.exception.GithubUserNotFoundException;
 import com.comeet.member.exception.MemberNotFoundException;
@@ -71,8 +72,9 @@ public class MemberService {
         return new LoginResponseDto(jwtService.encode(member.getId()));
     }
 
-    public MemberInfoResponseDto getMemberInfo(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+    public MemberInfoResponseDto getMemberInfo() {
+        Member member = memberRepository.findById(SecurityUtil.resolveMemberId())
+            .orElseThrow(MemberNotFoundException::new);
         return new MemberInfoResponseDto(member.getId(), member.getNickname(),
             member.getGithubId());
     }
@@ -85,8 +87,9 @@ public class MemberService {
      * TODO 멤버 정보 수정
      */
 
-    public GetOrganizationOfMemberDto getOrganizationOfMember(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+    public GetOrganizationOfMemberDto getOrganizationOfMember() {
+        Member member = memberRepository.findById(SecurityUtil.resolveMemberId())
+            .orElseThrow(MemberNotFoundException::new);
         return new GetOrganizationOfMemberDto(member.getOrganizations());
     }
 

--- a/src/main/java/com/comeet/organization/controller/OrganizationController.java
+++ b/src/main/java/com/comeet/organization/controller/OrganizationController.java
@@ -24,10 +24,9 @@ public class OrganizationController {
 
     @PostMapping()
     public ApiResponse<OrganizationInfoResponseDto> createOrganization(
-        @RequestBody CreateOrganizationRequestDto createOrganizationRequestDto,
-        @ModelAttribute("memberId") Long memberId) {
+        @RequestBody CreateOrganizationRequestDto createOrganizationRequestDto) {
         return ApiResponse.success(
-            organizationService.createOrganization(createOrganizationRequestDto, memberId));
+            organizationService.createOrganization(createOrganizationRequestDto));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/comeet/organization/service/OrganizationService.java
+++ b/src/main/java/com/comeet/organization/service/OrganizationService.java
@@ -1,5 +1,6 @@
 package com.comeet.organization.service;
 
+import com.comeet.config.security.SecurityUtil;
 import com.comeet.member.entity.Member;
 import com.comeet.member.exception.MemberNotFoundException;
 import com.comeet.member.repository.MemberRepository;
@@ -25,10 +26,9 @@ public class OrganizationService {
 
     @Transactional
     public OrganizationInfoResponseDto createOrganization(
-        CreateOrganizationRequestDto createOrganizationRequestDto, Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        CreateOrganizationRequestDto createOrganizationRequestDto) {
+        Member member = memberRepository.findById(SecurityUtil.resolveMemberId())
             .orElseThrow(MemberNotFoundException::new);
-
         Organization organization = Organization.of(createOrganizationRequestDto.getName());
         organization = organizationRepository.save(organization);
         member.addOrganization(organization);


### PR DESCRIPTION
## 변경사항

### Spring Cloud Feign 사용
- 기존 restTemplate 사용하는 부분을 Spring Cloud Feign 으로 대체하였습니다.

### token 관련 부분 유틸 클래스 생성
- 기존 apiControllerAdvice 에서 memberId형 변환해주고 있습니다.
- 유틸 클래스 생성해서 해당 기능 대체

### TODO 
- [ ] 프라이빗 레포나 PR 관련 커밋도 체크할 수 있도록 관련 외부 API 호출하는 부분 생성
- [ ] 커밋 외에 pr / 이슈 생성도 커밋으로 count하도록 api 추가
- [ ] 공통으로 사용되는 validation 함수 생성